### PR TITLE
ship config.yml to /usr/share and copy to user home ~/.calyptos

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include MANIFEST.in
 include README.md
-include euca-deploy.spec
+include calyptos.spec
 include etc/config.yml
 include examples/*

--- a/bin/calyptos
+++ b/bin/calyptos
@@ -3,8 +3,28 @@ import argparse
 from fabric.colors import yellow
 from stevedore import driver, extension
 from calyptos.rolebuilder import RoleBuilder
+import os
+import shutil
+
+dot_dir = os.path.expanduser('~/.calyptos')
+default_cfgfile = os.path.join(dot_dir + "/" + "config.yml")
+
+def locate_cfgfile():
+    if not os.path.isfile(default_cfgfile):
+        if not os.path.exists(dot_dir):
+            try:
+                os.makedirs(dot_dir)
+            except OSError as e:
+                print('Error: cannot create directory ~/.calyptos: %s' % e)
+        try:
+            shutil.copy('/usr/share/calyptos/etc/config.yml', default_cfgfile)
+        except shutil.Error as e:
+            print('Error: %s' % e)
+        except IOError as e:
+            print('Error: %s' % e.strerror)
 
 if __name__ == '__main__':
+    locate_cfgfile()
     parser = argparse.ArgumentParser()
     default_repo = 'https://github.com/eucalyptus/eucalyptus-cookbook'
     parser.add_argument('operation', choices=['validate',
@@ -13,7 +33,7 @@ if __name__ == '__main__':
                                               'provision',
                                               'debug',
                                               'uninstall'])
-    parser.add_argument('-c', '--config', default='etc/config.yml')
+    parser.add_argument('-c', '--config', default=default_cfgfile)
     parser.add_argument('-e', '--environment', default='etc/environment.yml')
     parser.add_argument('-p', '--password', default='foobar')
     parser.add_argument('-b', '--branch', default='euca-4.2')

--- a/bin/calyptos
+++ b/bin/calyptos
@@ -7,24 +7,46 @@ import os
 import shutil
 
 dot_dir = os.path.expanduser('~/.calyptos')
-default_cfgfile = os.path.join(dot_dir + "/" + "config.yml")
+# by default we look in users home dir first
+default_cfgfile = os.path.join(dot_dir, "config.yml")
+cfglist = []
+cfglist.append(default_cfgfile)
+cfglist.append('/usr/share/calyptos/config.yml')
 
 def locate_cfgfile():
-    if not os.path.isfile(default_cfgfile):
-        if not os.path.exists(dot_dir):
-            try:
-                os.makedirs(dot_dir)
-            except OSError as e:
-                print('Error: cannot create directory ~/.calyptos: %s' % e)
-        try:
-            shutil.copy('/usr/share/calyptos/etc/config.yml', default_cfgfile)
-        except shutil.Error as e:
-            print('Error: %s' % e)
-        except IOError as e:
-            print('Error: %s' % e.strerror)
+    # if we find that the config file is in /usr/share
+    # but the rpm is not installed, we copy it to ~/.calyptos
+    # because that means calyptos was installed by setup.py
+    for item in cfglist:
+        if os.path.isfile(item):
+            if item != default_cfgfile:
+                import rpm # I think this is required by other parts of python so I'm safe using it
+                ts = rpm.TransactionSet()
+                mi = ts.dbMatch("name","calyptos")
+                if (len(mi) == 0):
+                    if not os.path.isfile(default_cfgfile):
+                        if not os.path.exists(dot_dir):
+                            try:
+                                os.makedirs(dot_dir)
+                            except OSError as e:
+                                print('Error: cannot create directory ~/.calyptos: %s' % e)
+                        try:
+                            # if this copy works, return default_cfgfile
+                            # because it will be used going forward
+                            shutil.copy('/usr/share/calyptos/config.yml', default_cfgfile)
+                            return default_cfgfile
+                        except shutil.Error as e:
+                            print('Error: %s' % e)
+                        except IOError as e:
+                            print('Error: %s' % e.strerror)
+            # this is not in an else: block because its a
+            # last resort for the case where import rpm
+            # doesn't succeed above, because we still need
+            # to return a valid config file name
+            return item
 
 if __name__ == '__main__':
-    locate_cfgfile()
+    cfgfile = locate_cfgfile()
     parser = argparse.ArgumentParser()
     default_repo = 'https://github.com/eucalyptus/eucalyptus-cookbook'
     parser.add_argument('operation', choices=['validate',
@@ -33,7 +55,7 @@ if __name__ == '__main__':
                                               'provision',
                                               'debug',
                                               'uninstall'])
-    parser.add_argument('-c', '--config', default=default_cfgfile)
+    parser.add_argument('-c', '--config', default=cfgfile)
     parser.add_argument('-e', '--environment', default='etc/environment.yml')
     parser.add_argument('-p', '--password', default='foobar')
     parser.add_argument('-b', '--branch', default='euca-4.2')

--- a/calyptos.spec
+++ b/calyptos.spec
@@ -89,5 +89,5 @@ rm -rf $RPM_BUILD_ROOT
 /usr/bin/calyptos
 %{python_sitelib}/calyptos/*
 %{python_sitelib}/*.egg-info
-/usr/share/calyptos/etc/*
+/usr/share/calyptos/config.yml
 /usr/share/calyptos/examples/*

--- a/calyptos.spec
+++ b/calyptos.spec
@@ -69,9 +69,7 @@ Provisions the rest of the system or update the configuration of an existing sys
 ### Debug
 #### Not yet implemented!!!
 This step will grab all necessary information from a system in order to provide artifacts for use in debugging a problem.
-    
-    
-    
+
 
 
 %prep
@@ -81,7 +79,7 @@ This step will grab all necessary information from a system in order to provide 
 %{__python2} setup.py build
 
 %install
-%{__python2} setup.py install --skip-build --root=$RPM_BUILD_ROOT
+%{__python2} setup.py install --skip-build --root=$RPM_BUILD_ROOT --single-version-externally-managed
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -89,7 +87,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root)
 /usr/bin/calyptos
-%{python_sitelib}/eucadeploy/*
+%{python_sitelib}/calyptos/*
 %{python_sitelib}/*.egg-info
-%config /etc/calyptos/config.yml
+/usr/share/calyptos/etc/*
 /usr/share/calyptos/examples/*

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,6 @@ setup(
         'build_py': build_py_with_git_version,
         'sdist': sdist_with_git_version
     },
-    #data_files=[('/etc/calyptos/', ['etc/config.yml']),
-    #            ('/usr/share/calyptos/examples/', example_items)],
+    data_files=[('/usr/share/calyptos/etc', ['etc/config.yml']),
+                ('/usr/share/calyptos/examples/', example_items)],
 )

--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,6 @@ setup(
         'build_py': build_py_with_git_version,
         'sdist': sdist_with_git_version
     },
-    data_files=[('/usr/share/calyptos/etc', ['etc/config.yml']),
+    data_files=[('/usr/share/calyptos', ['etc/config.yml']),
                 ('/usr/share/calyptos/examples/', example_items)],
 )


### PR DESCRIPTION
This changes how we use the config.yml. Instead of placing in /etc
we will put it in /usr/share/calyptos/etc on install, then copy to
~/.calyptos in the user home dir when calyptos is executed.

@viglesiasce please also let me know if you prefer another way to call locate_cfgfile(), I'm not sure how these bootstrap type things are done in Python typically.  Without a class to run an **init**()  method I just stuck that method in main.
