### PR TITLE
install and setup requirements for source and rpm builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a tool for managing your Eucalyptus deployments
 
 ### On a CentOS 6 system:
 
-    yum install -y python-devel gcc git python-setuptools fabric PyYAML python-stevedore
+    yum install -y python-devel gcc git python-setuptools
     git clone https://github.com/eucalyptus/calyptos
     cd calyptos
     python setup.py install

--- a/calyptos.spec
+++ b/calyptos.spec
@@ -23,7 +23,7 @@ Url: https://github.com/eucalyptus/calyptos/
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 
-Requires: fabric PyYAML git python-stevedore python-click
+Requires: fabric PyYAML git python-stevedore python-click argparse<=1.2.2
 
 %description
 # Calyptos

--- a/calyptos.spec
+++ b/calyptos.spec
@@ -23,7 +23,7 @@ Url: https://github.com/eucalyptus/calyptos/
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 
-Requires: fabric PyYAML git python-stevedore python-click argparse<=1.2.2
+Requires: fabric PyYAML git python-stevedore python-click argparse
 
 %description
 # Calyptos

--- a/calyptos.spec
+++ b/calyptos.spec
@@ -23,7 +23,7 @@ Url: https://github.com/eucalyptus/calyptos/
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 
-Requires: fabric PyYAML git python-stevedore python-click argparse
+Requires: fabric PyYAML git python-stevedore python-click python-argparse
 
 %description
 # Calyptos

--- a/calyptos.spec
+++ b/calyptos.spec
@@ -22,6 +22,8 @@ Url: https://github.com/eucalyptus/calyptos/
 
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
+BuildRequires: python-argparse
+BuildRequires: python-pbr
 
 Requires: fabric PyYAML git python-stevedore python-click python-argparse
 

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@ from distutils.command.sdist import sdist
 import os.path
 import subprocess
 import glob
+import multiprocessing
+import sys
 
 from setuptools import setup, find_packages
 
@@ -87,8 +89,11 @@ setup(
     packages=find_packages(),
     test_suite='nose.collector',
     tests_require=['nose'],
-    install_requires=['fabric', 'PyYaml', 'argparse', 'stevedore', 'sphinx',
-                      'pbr >= 0.10.7', 'six >= 1.9.0'],
+    # setup requires enables modules that are used during build/install of calyptos
+    setup_requires=['pbr==0.11.0'] + (['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []),
+    # argparse is only required if python==2.6
+    install_requires=['pbr==0.11.0', 'fabric', 'PyYaml', 'stevedore<1.4.0', 'sphinx']
+                     + (['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []),
     scripts=['bin/calyptos'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,12 @@ with open('README.md') as f:
 
 example_items = glob.glob('examples/*')
 
+# argparse is only required if python==2.6
+if sys.version_info[:2] == (2, 6):
+    argparse_list = ['argparse<=1.2.2']
+else:
+    argparse_list = []
+
 setup(
     name='calyptos',
     version=__version__,
@@ -90,9 +96,8 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     # setup requires enables modules that are used during build/install of calyptos
-    setup_requires=(['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []) + ['pbr'],
-    # argparse is only required if python==2.6
-    install_requires=(['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []) + ['pbr==0.11.0', 'fabric', 'PyYaml', 'stevedore<1.4.0', 'sphinx'],
+    setup_requires= argparse_list + ['pbr'],
+    install_requires= argparse_list + ['pbr==0.11.0', 'fabric', 'PyYaml', 'stevedore<1.4.0', 'sphinx'],
     scripts=['bin/calyptos'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from distutils.command.sdist import sdist
 import os.path
 import subprocess
 import glob
-import multiprocessing
 import sys
 
 from setuptools import setup, find_packages
@@ -78,11 +77,15 @@ with open('README.md') as f:
 
 example_items = glob.glob('examples/*')
 
-# argparse is only required if python==2.6
-if sys.version_info[:2] == (2, 6):
-    argparse_list = ['argparse<=1.2.2']
-else:
-    argparse_list = []
+
+
+requirements = ['fabric', 'PyYaml', 'stevedore', 'sphinx',
+                'pbr >= 0.10.7', 'six >= 1.9.0']
+setup_requirements = ['pbr']
+# argparse is only required if python<2.7
+if sys.version_info < (2, 7):
+    requirements.insert(0, 'argparse<=1.2.2') # prepend using insert instead of appending
+    setup_requirements.insert(0, 'argparse<=1.2.2') # prepend using insert instead of appending
 
 setup(
     name='calyptos',
@@ -96,8 +99,8 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     # setup requires enables modules that are used during build/install of calyptos
-    setup_requires= argparse_list + ['pbr'],
-    install_requires= argparse_list + ['pbr==0.11.0', 'fabric', 'PyYaml', 'stevedore<1.4.0', 'sphinx'],
+    setup_requires=setup_requirements,
+    install_requires=requirements,
     scripts=['bin/calyptos'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     # setup requires enables modules that are used during build/install of calyptos
-    setup_requires=(['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []) + ['pbr==0.11.0'],
+    setup_requires=(['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []) + ['pbr'],
     # argparse is only required if python==2.6
     install_requires=(['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []) + ['pbr==0.11.0', 'fabric', 'PyYaml', 'stevedore<1.4.0', 'sphinx'],
     scripts=['bin/calyptos'],

--- a/setup.py
+++ b/setup.py
@@ -90,10 +90,9 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     # setup requires enables modules that are used during build/install of calyptos
-    setup_requires=['pbr==0.11.0'] + (['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []),
+    setup_requires=(['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []) + ['pbr==0.11.0'],
     # argparse is only required if python==2.6
-    install_requires=['pbr==0.11.0', 'fabric', 'PyYaml', 'stevedore<1.4.0', 'sphinx']
-                     + (['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []),
+    install_requires=(['argparse<=1.2.2'] if sys.version_info[:2] == (2, 6) else []) + ['pbr==0.11.0', 'fabric', 'PyYaml', 'stevedore<1.4.0', 'sphinx'],
     scripts=['bin/calyptos'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This prevents the error I was seeing in which pbr_json couldn't be imported.  Also resolve issue 30 opened by gholms so we don't require argparse if python == 2.7.
