### PR TITLE
Removed ports 8778 and 18778 from check_ports.py; ports originally us…

### DIFF
--- a/calyptos/plugins/debugger/check_ports.py
+++ b/calyptos/plugins/debugger/check_ports.py
@@ -26,14 +26,19 @@ class CheckPorts(DebuggerPlugin):
         for host, netstat in ports.iteritems():
             closed_ports = []
             if host in roles['clc']:
+                self.info('Confirm reserved ports are open on Cloud Controller')
                 check_port_map(clc_ports)
             if host in roles['user-facing']:
+                self.info('Confirm reserved ports are open on User Facing Services')
                 check_port_map(ufs_ports)
             if host in roles['cluster-controller']:
+                self.info('Confirm reserved ports are open on Cluster Controller')
                 check_port_map(cc_ports)
             if host in roles['storage-controller']:
+                self.info('Confirm reserved ports are open on Storage Controller')
                 check_port_map(sc_ports)
             if host in roles['node-controller']:
+                self.info('Confirm reserved ports are open on Node Controller')
                 check_port_map(nc_ports)
             if closed_ports:
                 self.warning('Required ports ' +

--- a/calyptos/plugins/debugger/check_ports.py
+++ b/calyptos/plugins/debugger/check_ports.py
@@ -9,13 +9,13 @@ class CheckPorts(DebuggerPlugin):
             ports = self.run_command_on_hosts('netstat -lnp', all_hosts)
         roles = self.component_deployer.get_roles()
         clc_ports = {'tcp': [8773, 8777, 8443, 8779],
-                     'udp': [7500, 8773, 8778, 18778]}
+                     'udp': [7500, 8773]}
         ufs_ports = {'tcp': [53, 8773, 8779],
-                    'udp': [53, 7500, 8773, 8778, 18778]}
+                    'udp': [53, 7500, 8773]}
         cc_ports = {'tcp': [8774],
                     'udp': []}
         sc_ports = {'tcp': [8773, 8779],
-                    'udp': [7500, 8778, 8773, 18778]}
+                    'udp': [7500, 8773]}
         nc_ports = {'tcp': [8775],
                     'udp': []}
         def check_port_map(port_map):


### PR DESCRIPTION
Ports 8778 and 18778 were originally used in <=4.1.x as [bind ports for multicast communication between all Eucalyptus Java Components](https://www.eucalyptus.com/docs/eucalyptus/4.1.2/index.html#install-guide/preparing_firewalls.html).  Looks like this changed for 4.2.x.  

Using this updated `check_ports.py`, results from calyptos are as follows:

```
...
[DEBUG PASSED        ] 10.111.5.91: Open udp.*:7500
[DEBUG PASSED        ] 10.111.5.91: Open udp.*:8773
[DEBUG PASSED        ] 10.111.5.91: Open tcp.*:8773
[DEBUG PASSED        ] 10.111.5.91: Open tcp.*:8779
[DEBUG PASSED        ] 10.111.5.79: Open udp.*:53
[DEBUG PASSED        ] 10.111.5.79: Open udp.*:7500
[DEBUG PASSED        ] 10.111.5.79: Open udp.*:8773
[DEBUG PASSED        ] 10.111.5.79: Open tcp.*:53
[DEBUG PASSED        ] 10.111.5.79: Open tcp.*:8773
[DEBUG PASSED        ] 10.111.5.79: Open tcp.*:8779
[DEBUG PASSED        ] 10.111.5.81: Open tcp.*:8774
[DEBUG PASSED        ] 10.111.5.70: Open udp.*:7500
[DEBUG PASSED        ] 10.111.5.70: Open udp.*:8773
[DEBUG PASSED        ] 10.111.5.70: Open tcp.*:8773
[DEBUG PASSED        ] 10.111.5.70: Open tcp.*:8777
[DEBUG PASSED        ] 10.111.5.70: Open tcp.*:8443
[DEBUG PASSED        ] 10.111.5.70: Open tcp.*:8779
[DEBUG PASSED        ] 10.111.5.181: Open tcp.*:8775
....
```
